### PR TITLE
Add option for avoiding lk cache and scrubbing files

### DIFF
--- a/elk/ensemble.py
+++ b/elk/ensemble.py
@@ -73,9 +73,13 @@ class EnsembleLC:
             if create_it == "" or create_it.lower() == "y":
                 # create the folder
                 os.mkdir(output_path)
-                os.mkdir(os.path.join(output_path, 'cache'))
             else:
                 output_path = None
+
+        # if we wan't to avoid the lk cache we shall need our own dummy
+        if no_lk_cache and not os.path.exists(os.path.join(output_path, 'cache')):
+            os.mkdir(os.path.join(output_path, 'cache'))
+            os.mkdir(os.path.join(output_path, 'cache', 'tesscut'))
 
         # check subfolders
         self.save = {"lcs": False, "figures": False}

--- a/elk/ensemble.py
+++ b/elk/ensemble.py
@@ -73,6 +73,7 @@ class EnsembleLC:
             if create_it == "" or create_it.lower() == "y":
                 # create the folder
                 os.mkdir(output_path)
+                os.mkdir(os.path.join(output_path, 'temp'))
             else:
                 output_path = None
 
@@ -138,7 +139,9 @@ class EnsembleLC:
     def downloadable(self, ind):
         # use a Try statement to see if we can download the cluster data
         try:
-            tpfs = self.tess_search_results[ind].download(cutout_size=(self.cutout_size, self.cutout_size))
+            download_dir = os.path.join(self.output_path, 'temp') if self.no_cache else None
+            tpfs = self.tess_search_results[ind].download(cutout_size=(self.cutout_size, self.cutout_size),
+                                                          download_dir=download_dir)
         except lk.search.SearchError:
             tpfs = None
         return tpfs

--- a/elk/ensemble.py
+++ b/elk/ensemble.py
@@ -15,7 +15,7 @@ from .utils import flux_to_mag, flux_err_to_mag_err
 class EnsembleLC:
     def __init__(self, radius, cluster_age, output_path="./", cluster_name=None, location=None,
                  percentile=80, cutout_size=99, scattered_light_frequency=5, n_pca=6, verbose=False,
-                 debug=False):
+                 no_cache=False, debug=False):
         """Class for generating lightcurves from TESS cutouts
 
         Parameters
@@ -43,6 +43,9 @@ class EnsembleLC:
             Number of principle components to use in the DesignMatrix, by default 6
         verbose : `bool`, optional
             Whether to print out information and progress bars, by default False
+        no_cache : `bool`, optional
+            Whether to skip using the LightKurve cache and scrub downloads instead (can be useful for runs
+            on a computing cluster with limited memory space), by default False
         debug : `bool`, optional
             #TODO DELETE THIS, by default False
         """
@@ -100,6 +103,7 @@ class EnsembleLC:
         self.scattered_light_frequency = scattered_light_frequency
         self.n_pca = n_pca
         self.verbose = verbose
+        self.no_cache = no_cache
         self.debug = debug
 
     def __repr__(self):

--- a/elk/ensemble.py
+++ b/elk/ensemble.py
@@ -339,6 +339,10 @@ class EnsembleLC:
             # So Calling function to download and correct data
             self.get_lcs()
 
+            # clear out the cache after we're done making lightcurves
+            if self.no_lk_cache:
+                self.clear_cache()
+
             # Making the Output Table
             name___ = [self.cluster_name]
             HTD = [True]

--- a/elk/tests/test_class.py
+++ b/elk/tests/test_class.py
@@ -7,7 +7,9 @@ c = EnsembleLC(output_path="../../output",
                radius=.046,
                cluster_age=7.75,
                cutout_size=10,
-               debug=True)
+               debug=True,
+               verbose=True,
+               no_lk_cache=True)
 
 c.lightcurves_summary_file()
 c.access_lightcurve(1)

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ long_description_content_type = text/markdown
 #   - environment.yml
 
 [options]
-python_requires = >=3.10
+python_requires = >=3.9
 packages = find: 
 install_requires = 
     numpy


### PR DESCRIPTION
You can now use `no_lk_cache=True` to avoid accumulating a bunch of cached files on computer clusters. You can try this out with the updated `test_class.py` file 🙂 

This closes #14.