### PR TITLE
Saving and loading!

### DIFF
--- a/elk/ensemble.py
+++ b/elk/ensemble.py
@@ -354,8 +354,8 @@ class EnsembleLC:
                       'n_obs': [self.sectors_available], 'n_good_obs': [self.n_good_obs],
                       'n_failed_download': [self.n_failed_download], 'n_near_edge': [self.n_near_edge],
                       'n_scatter_light': [self.n_scattered_light],
-                      'lc_lens': [[len(lc.corrected_lc) for lc in self.lcs]],
-                      'which_sectors_good': [[lc.sector for lc in self.lcs]]})
+                      'lc_lens': [[len(lc.corrected_lc) for lc in self.lcs if lc is not None]],
+                      'which_sectors_good': [[lc.sector for lc in self.lcs if lc is not None]]})
 
     def access_lightcurve(self, observation):
         """Function to access downloaded and corrected sector lightcurved

--- a/elk/ensemble.py
+++ b/elk/ensemble.py
@@ -66,7 +66,7 @@ class EnsembleLC:
                 cluster_age = np.log10(cluster_age.to(u.yr).value)
 
         # check main output folder
-        if not os.path.exists(output_path):
+        if output_path is not None and not os.path.exists(output_path):
             print(f"WARNING: There is no output folder at the path that you supplied ({output_path})")
             create_it = input(("  Would you like me to create it for you? "
                                "(If not then no files will be saved) [Y/n]"))

--- a/elk/ensemble.py
+++ b/elk/ensemble.py
@@ -282,28 +282,21 @@ class EnsembleLC:
                 self.n_scattered_light += 1
                 return
             else:
+                # This Else Statement means that the Lightcurve is good and has passed our quality checks
                 if self.verbose:
                     print(sector_ind, "Passed Quality Tests")
                 self.n_good_obs += 1
                 self.which_sectors_good.append(sector_ind)
-                # This Else Statement means that the Lightcurve is good and has passed our quality checks
-
-                if self.output_path is not None and self.save["lcs"]:
-                    lc.full_corrected_lightcurve_table.write(os.path.join(self.output_path,
-                                                                          "Corrected_LCs",
-                                                                          self.callable + ".fits"),
-                                                             format='fits', append=True)
+                self.lcs[sector_ind] = lc
 
                 # Now I am going to save a plot of the light curve to go visually inspect later
-                range_ = max(lc.full_corrected_lightcurve_table['flux']) - min(lc.full_corrected_lightcurve_table['flux'])
+                range_ = max(lc.corrected_lc['flux']) - min(lc.corrected_lc['flux'])
                 fig = plt.figure()
                 plt.title(f'Observation: {sector_ind}')
-                plt.plot(lc.full_corrected_lightcurve_table['time'], lc.full_corrected_lightcurve_table['flux'],
-                         color='k', linewidth=.5)
+                plt.plot(lc.corrected_lc['time'], lc.corrected_lc['flux'], color='k', linewidth=.5)
                 plt.xlabel('Delta Time [Days]')
                 plt.ylabel('Flux [e/s]')
-                plt.text(lc.full_corrected_lightcurve_table['time'][0],
-                         (max(lc.full_corrected_lightcurve_table['flux'])-(range_*0.05)),
+                plt.text(lc.corrected_lc['time'][0], (max(lc.corrected_lc['flux'])-(range_*0.05)),
                          self.callable, fontsize=14)
 
                 if self.output_path is not None and self.save["figures"]:
@@ -312,7 +305,7 @@ class EnsembleLC:
                     plt.savefig(path, format='png', bbox_inches="tight")
                 plt.close(fig)
 
-                self.lc_lens.append(len(lc.full_corrected_lightcurve_table))
+                self.lc_lens.append(len(lc.corrected_lc))
         if self.no_lk_cache():
             self.clear_cache()
 

--- a/elk/ensemble.py
+++ b/elk/ensemble.py
@@ -400,7 +400,7 @@ def from_fits(filepath, **kwargs):
         new_ecl.location = details.header["Location"]
         new_ecl.callable = new_ecl.cluster_name if new_ecl.cluster_name is not None else new_ecl.location
         new_ecl.radius = details.header["Radius [deg]"]
-        new_ecl.cluster_age = details.header["Log_Age"]
+        new_ecl.cluster_age = details.header["Log Age"]
         new_ecl.sectors_available = details.header["n_obs_available"]
         new_ecl.n_good_obs = details.header["n_good_obs"]
         new_ecl.n_failed_download = details.header["n_failed_download"]

--- a/elk/lightcurve.py
+++ b/elk/lightcurve.py
@@ -26,6 +26,17 @@ class SimpleCorrectedLightcurve():
             self.corrected_lc = lk.LightCurve(time=time, flux=flux, flux_err=flux_err)
             self.sector = sector
 
+        self.hdu = fits.BinTableHDU.from_columns(
+            [fits.Column(name='time', format='D', array=self.corrected_lc.time.value),
+             fits.Column(name='flux', format='D', array=self.corrected_lc.flux.value),
+             fits.Column(name='flux_err', format='D', array=self.corrected_lc.flux_err.value),
+             fits.Column(name='mag', format='D', array=flux_to_mag(self.corrected_lc.flux.value)),
+             fits.Column(name='mag_err', format='D',
+                         array=flux_err_to_mag_err(self.corrected_lc.flux.value,
+                                                   self.corrected_lc.flux_err.value))]
+        )
+        self.hdu.header.set('sector', self.sector)
+
 
 class TESSCutLightcurve(SimpleCorrectedLightcurve):
     def __init__(self, radius, lk_search_result=None, tpfs=None,

--- a/elk/lightcurve.py
+++ b/elk/lightcurve.py
@@ -1,6 +1,5 @@
 import numpy as np
 import astropy.units as u
-from astropy.table import Table
 from astropy.io import fits
 import lightkurve as lk
 from tqdm import tqdm
@@ -19,19 +18,14 @@ class SimpleCorrectedLightcurve():
         if has_file:
             with fits.open(fits_path) as hdul:
                 hdu = hdul[hdu_index]
-                self.corrected_lc = Table({
-                    "time": hdu.data["time"] * u.day,
-                    "flux": hdu.data["flux"] * u.electron / u.s,
-                    "flux_err": hdu.data["flux_err"] * u.electron / u.s
-                })
+                self.corrected_lc = lk.LightCurve(time=hdu.data["time"] * u.day,
+                                                  flux=hdu.data["flux"] * u.electron / u.s,
+                                                  flux_err=hdu.data["flux_err"] * u.electron / u.s)
                 self.sector = hdu.header["sector"]
         else:
-            self.corrected_lc = Table({
-                "time": time,
-                "flux": flux,
-                "flux_err": flux_err
-            })
+            self.corrected_lc = lk.LightCurve(time=time, flux=flux, flux_err=flux_err)
             self.sector = sector
+
 
 class TESSCutLightcurve(SimpleCorrectedLightcurve):
     def __init__(self, radius, lk_search_result=None, tpfs=None,

--- a/elk/lightcurve.py
+++ b/elk/lightcurve.py
@@ -161,9 +161,10 @@ class TESSCutLightcurve():
              fits.Column(name='mag', format='D', array=flux_to_mag(self.corrected_lc.flux.value)),
              fits.Column(name='mag_err', format='D',
                          array=flux_err_to_mag_err(self.corrected_lc.flux.value,
-                                                   self.corrected_lc.flux_err.value)]
+                                                   self.corrected_lc.flux_err.value))]
         )
-        hdu.header.set('sector', self.sector)
+        self.hdu.header.set('sector', self.sector)
+        # TODO: add a output option on a per lightcurve basis
 
     def correct_pixel(self, i, j):
         # create a lightcurve for just this pixel

--- a/elk/lightcurve.py
+++ b/elk/lightcurve.py
@@ -20,9 +20,9 @@ class SimpleCorrectedLightcurve():
             with fits.open(fits_path) as hdul:
                 hdu = hdul[hdu_index]
                 self.corrected_lc = Table({
-                    "time": hdu["time"] * u.day,
-                    "flux": hdu["flux"] * u.electron / u.s,
-                    "flux_err": hdu["flux_err"] * u.electron / u.s
+                    "time": hdu.data["time"] * u.day,
+                    "flux": hdu.data["flux"] * u.electron / u.s,
+                    "flux_err": hdu.data["flux_err"] * u.electron / u.s
                 })
                 self.sector = hdu.header["sector"]
         else:

--- a/elk/tests/test_save_load.py
+++ b/elk/tests/test_save_load.py
@@ -11,7 +11,7 @@ c = elk.ensemble.EnsembleLC(output_path="../../output",
                verbose=True,
                no_lk_cache=True)
 
-c.lightcurves_summary_file()
+print(c.lightcurves_summary_file())
 
 del c
 

--- a/elk/tests/test_save_load.py
+++ b/elk/tests/test_save_load.py
@@ -22,3 +22,20 @@ for lc in c.lcs:
     print(elk.stats.J_stetson(lc.corrected_lc.time.value, lc.corrected_lc.flux.value, lc.corrected_lc.flux_err.value))
     plt.plot(lc.corrected_lc.time.value, lc.corrected_lc.flux.value)
     plt.show()
+
+del c
+
+c = elk.ensemble.EnsembleLC(output_path="../../output",
+               cluster_name='NGC 419',
+               location='23.58271, +61.1236',
+               radius=.046,
+               cluster_age=7.75,
+               cutout_size=10,
+               debug=True,
+               verbose=True,
+               no_lk_cache=True)
+
+for lc in c.lcs:
+    print(elk.stats.J_stetson(lc.corrected_lc.time.value, lc.corrected_lc.flux.value, lc.corrected_lc.flux_err.value))
+    plt.plot(lc.corrected_lc.time.value, lc.corrected_lc.flux.value)
+    plt.show()

--- a/elk/tests/test_save_load.py
+++ b/elk/tests/test_save_load.py
@@ -1,0 +1,24 @@
+import elk
+import matplotlib.pyplot as plt
+
+c = elk.ensemble.EnsembleLC(output_path="../../output",
+               cluster_name='NGC 419',
+               location='23.58271, +61.1236',
+               radius=.046,
+               cluster_age=7.75,
+               cutout_size=10,
+               debug=True,
+               verbose=True,
+               no_lk_cache=True)
+
+c.lightcurves_summary_file()
+
+del c
+
+c = elk.ensemble.from_fits("../../output/Corrected_LCs/NGC 419output_table.fits")
+print(c)
+
+for lc in c.lcs:
+    print(elk.stats.J_stetson(lc.corrected_lc.time.value, lc.corrected_lc.flux.value, lc.corrected_lc.flux_err.value))
+    plt.plot(lc.corrected_lc.time.value, lc.corrected_lc.flux.value)
+    plt.show()


### PR DESCRIPTION
Very pleased with this one 😁 You can now fully save and load these classes with built in functions. Everything is saved to a fits files which is organised like this:

- One PrimaryHDU that contains the metadata in the header (e.g. number of good obs, radius, name etc.)
- One TableHDU per good observation, within each of which are the flux time etc. in the data and the sector number in the header

`lightcurves_summary_file` will now save the whole lot and `from_fits` will pull it all back in.

This one should definitely be tested in detail - I recommend doing a test run with a small cutout size, and seeing if you can load it all back in afterwards using `from_fits`.

Note that `access_lightcurves` is broken but that's on purpose - I think it's going to become obsolete since lightcurves are all loaded into the .lcs array and I can move the plotting to the plot module soon.

This fixes #36 and #31 