### PR TITLE
Diagnose light curve GIF

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Help us squash those bugs in ``elk``!
+about: Help us squash those bugs in elk!
 title: ''
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Help us squash those bugs in elk!
 title: ''
-labels: bug
+labels: 'bug :bug:'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/documentation-problem.md
+++ b/.github/ISSUE_TEMPLATE/documentation-problem.md
@@ -2,7 +2,7 @@
 name: Documentation problem
 about: A part of the documentation is wrong/misleading/unclear
 title: ''
-labels: documentation
+labels: 'documentation :scroll:'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Got an idea for adding something to ``elk``? Let us know!
+about: Got an idea for adding something to elk? Let us know!
 title: ''
 labels: enhancement
 assignees: ''
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Describe the new feature you'd like**
-A clear and concise description of what you want to happen. E.g. "I love how ``elk`` can create light curves, but I think a great improvement would be for it to also fold my laundry."
+A clear and concise description of what you want to happen. E.g. "I love how elk can create light curves, but I think a great improvement would be for it to also fold my laundry."
 
 **Any suggestions for how to implement this**
 Is there a particular way you would implement this? How could this integrate into the existing code?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Got an idea for adding something to elk? Let us know!
 title: ''
-labels: enhancement
+labels: 'enhancement :sunglasses'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,7 @@
 name: Question
 about: Confused about something in elk? Not sure how to use a function? Feel free to ask questions here!
 title: ''
-labels: question
+labels: 'question'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,10 +1,10 @@
 ---
 name: Question
-about: Confused about something in ``elk``? Not sure how to use a function? Feel free to ask questions here!
+about: Confused about something in elk? Not sure how to use a function? Feel free to ask questions here!
 title: ''
 labels: question
 assignees: ''
 
 ---
 
-Use this issue to ask any questions about how ``elk`` functions work, how best to use ``elk`` for your project or anything else you need help with! Wherever possible please include code examples to make it easier to help you!
+Use this issue to ask any questions about how elk functions work, how best to use elk for your project or anything else you need help with! Wherever possible please include code examples to make it easier to help you!

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ cython_debug/
 output/
 *.npy
 docs/api/
+elk/tests/*.png
+elk/tests/*.gif

--- a/elk/lightcurve.py
+++ b/elk/lightcurve.py
@@ -611,21 +611,19 @@ class TESSCutLightcurve(BasicLightcurve):
 
             cbar = fig.colorbar(im, ax=axes[1])
             cbar.set_label('LS periodogram power')
-            axes[1].set_title('Max Lomb Scargle Power')
+            axes[1].set_title('Maximum Lomb Scargle Power')
 
-            axes[1].annotate((f'Frequency: {(lower + upper) / 2:1.2f} 1/day '
-                              f'(Range: [{lower:1.2f}, {upper:1.2f}])'), xy=(0.5, 0.95),
+            axes[1].annotate((f'Frequency: {(lower + upper) / 2:1.2f} 1/day\n'
+                              f'Range: [{lower:1.2f}, {upper:1.2f}] 1/day'), xy=(0.5, 0.95),
                              xycoords="axes fraction", ha="center", va="top")
 
             # plot the LS periodogram for the ensemble cluster LC
-            fig, axes[2] = self.plot_periodogram(self.omega, fig=fig, ax=axes[2], show=False)
+            fig, axes[2] = self.plot_periodogram(self.omega, fig=fig, ax=axes[2], show=False, title="Ensemble Light Curve Periodogram")
             axes[2].axvspan(lower, upper, color="lightgrey", zorder=-1)
-            for lim in [lower, upper]:
-                axes[2].axvline(lim, color='grey', linestyle='dotted', zorder=-1)
-            fig.savefig(os.path.join(output_path, f'gif_plot_frame_{i}.png'))
-            # plt.show()
-            plt.close(fig)
 
+            # save and close the figure and move on to the next
+            fig.savefig(os.path.join(output_path, f'gif_plot_frame_{i}.png'))
+            plt.close(fig)
             i += 1
 
         # convert individual frames to a GIF
@@ -633,4 +631,3 @@ class TESSCutLightcurve(BasicLightcurve):
         with imageio.get_writer(gif_path, mode='I', fps=1.5) as writer:
             for i in range(len(freq_bins) - 1):
                 writer.append_data(imageio.imread(os.path.join(output_path, f'gif_plot_frame_{i}.png')))
-                

--- a/elk/lightcurve.py
+++ b/elk/lightcurve.py
@@ -633,7 +633,7 @@ class TESSCutLightcurve(BasicLightcurve):
             axes[2].axvspan(lower, upper, color="lightgrey", zorder=-1)
 
             # save and close the figure and move on to the next
-            fig.savefig(os.path.join(output_path, f'gif_plot_frame_{i}.png'))
+            fig.savefig(os.path.join(output_path, f'gif_plot_frame_{i}.png'), bbox_inches="tight")
             plt.close(fig)
             i += 1
 

--- a/elk/lightcurve.py
+++ b/elk/lightcurve.py
@@ -575,7 +575,7 @@ class TESSCutLightcurve(BasicLightcurve):
 
         return systematics_model, full_model, full_model_normalized
 
-    def make_periodogram_peak_pixels_gif(self, output_path, freq_bins='auto', identifier=''):
+    def diagnose_lc_periodogram(self, output_path, freq_bins='auto', identifier=''):
         """Create gif showing pixels that contribute power to periodogram for different frequency ranges
 
         The GIF has 3 panels, the first shows the overall TPFs and aperture, the second shows the maximum
@@ -663,11 +663,12 @@ class TESSCutLightcurve(BasicLightcurve):
             axes[1].add_artist(circle)
 
             # plot the LS periodogram for the ensemble cluster LC
-            fig, axes[2] = self.plot_periodogram(self.omega, fig=fig, ax=axes[2], show=False, title="Ensemble Light Curve Periodogram")
+            fig, axes[2] = self.plot_periodogram(self.omega, fig=fig, ax=axes[2], show=False,
+                                                 title="Ensemble Light Curve Periodogram")
             axes[2].axvspan(lower, upper, color="lightgrey", zorder=-1)
 
             # save and close the figure and move on to the next
-            fig.savefig(os.path.join(output_path, f'gif_plot_frame_{i}.png'), bbox_inches="tight")
+            fig.savefig(os.path.join(output_path, f'{identifier}_gif_plot_frame_{i}.png'), bbox_inches="tight")
             plt.close(fig)
             i += 1
 
@@ -675,4 +676,5 @@ class TESSCutLightcurve(BasicLightcurve):
         gif_path = os.path.join(output_path, 'pixel_power_gif.gif')
         with imageio.get_writer(gif_path, mode='I', fps=1.5) as writer:
             for i in range(len(edges)):
-                writer.append_data(imageio.imread(os.path.join(output_path, f'gif_plot_frame_{i}.png')))
+                writer.append_data(imageio.imread(os.path.join(output_path,
+                                                               f'{identifier}_gif_plot_frame_{i}.png')))

--- a/elk/lightcurve.py
+++ b/elk/lightcurve.py
@@ -599,12 +599,21 @@ class TESSCutLightcurve(BasicLightcurve):
             # plot the entire target pixel file in the first axis
             self.quality_tpfs.plot(frame=len(self.quality_tpfs) // 2, ax=axes[0])
 
-            # get the indices of the aperture pixels and plot a marker on each pixel that matches
-            pixel_inds = np.argwhere(self.star_mask)
-            axes[0].scatter(axes[0].get_xlim()[0] + pixel_inds[:, 1] + 0.5,
-                            axes[0].get_ylim()[0] + pixel_inds[:, 0] + 0.5,
-                            c='r', s=1, alpha=0.5)
+            # create a circle around the aperture
+            x_range = axes[0].get_xlim()[1] - axes[0].get_xlim()[0]
+            y_range = axes[0].get_ylim()[1] - axes[0].get_ylim()[0]
+            circle = plt.Circle(xy=(axes[0].get_xlim()[0] + x_range / 2, axes[0].get_ylim()[0] + y_range / 2),
+                                radius=(self.radius * u.deg / TESS_RESOLUTION).to(u.pixel).value,
+                                edgecolor="red", facecolor="none", linewidth=2)
+            axes[0].add_artist(circle)
             axes[0].set_title(f'{identifier} ({self.quality_tpfs[0].ra}, {self.quality_tpfs[0].dec})')
+
+            # @Tobin uncomment this if you'd rather highlight pixels instead of/in addition to the circle
+            # get the indices of the aperture pixels and plot a marker on each pixel that matches
+            # pixel_inds = np.argwhere(self.star_mask)
+            # axes[0].scatter(axes[0].get_xlim()[0] + pixel_inds[:, 1] + 0.5,
+            #                 axes[0].get_ylim()[0] + pixel_inds[:, 0] + 0.5,
+            #                 c='r', s=1, alpha=0.5)
 
             # create a mask for the frequency range
             frequency_mask = (self.omega >= lower) & (self.omega < upper)
@@ -627,6 +636,11 @@ class TESSCutLightcurve(BasicLightcurve):
             axes[1].annotate((f'Frequency: {(lower + upper) / 2:1.2f} 1/day\n'
                               f'Range: [{lower:1.2f}, {upper:1.2f}] 1/day'), xy=(0.5, 0.95),
                              xycoords="axes fraction", ha="center", va="top")
+
+            circle = plt.Circle(xy=(axes[0].get_xlim()[0] + x_range / 2, axes[0].get_ylim()[0] + y_range / 2),
+                                radius=(self.radius * u.deg / TESS_RESOLUTION).to(u.pixel).value,
+                                edgecolor="grey", facecolor="none", linestyle="dotted")
+            axes[1].add_artist(circle)
 
             # plot the LS periodogram for the ensemble cluster LC
             fig, axes[2] = self.plot_periodogram(self.omega, fig=fig, ax=axes[2], show=False, title="Ensemble Light Curve Periodogram")

--- a/elk/lightcurve.py
+++ b/elk/lightcurve.py
@@ -576,6 +576,26 @@ class TESSCutLightcurve(BasicLightcurve):
         return systematics_model, full_model, full_model_normalized
 
     def make_periodogram_peak_pixels_gif(self, output_path, freq_bins='auto', identifier=''):
+        """Create gif showing pixels that contribute power to periodogram for different frequency ranges
+
+        The GIF has 3 panels, the first shows the overall TPFs and aperture, the second shows the maximum
+        power in each pixel for this frequency bin (and is annotated with the frequency/range used for this
+        frame) and the last panel shows the overall ensemble light curve periodogram with the frame's
+        frequency range highlighted.
+
+        NOTE: `self.correct_lc` must have already been run and `self.save_pixel_periodograms` must be true.
+
+        Parameters
+        ----------
+        output_path : `str`
+            Path to a folder in which to output the gif and frames
+        freq_bins : `str` or `int` or :class:`~numpy.ndarray`, optional
+            Frequency bins to use for the GIF. Either 'auto' to create a frame for each peak in the
+            periodogram, an integer to use log-spaced bins in the periodogram range or an array of bin edges,
+            by default 'auto'
+        identifier : `str`, optional
+            An identifier for this target to put in the title (e.g. the cluster name), by default ''
+        """
         if isinstance(freq_bins, str):
             assert freq_bins == "auto", "`freq_bins` can only be a str if it is equal to 'auto'"
             self.to_periodogram(self.omega)

--- a/elk/lightcurve.py
+++ b/elk/lightcurve.py
@@ -596,6 +596,16 @@ class TESSCutLightcurve(BasicLightcurve):
         identifier : `str`, optional
             An identifier for this target to put in the title (e.g. the cluster name), by default ''
         """
+        # ensure the necessary data is available to run this
+        assert self.save_pixel_periodograms, ("Pixel periodograms not available. Set "
+                                              "`self.save_pixel_periodograms=True` and re-run "
+                                              "`self.correct_lc`")
+
+        # mask the pixel powers to only be for pixels in the aperture
+        aperture_powers = np.asarray(self.pixel_periodograms)[self.star_mask.flatten()]
+        assert len(aperture_powers) > 0, "No pixel periodograms found - did you run `self.correct_lc`?"
+
+        # convert input into bin edges
         if isinstance(freq_bins, str):
             assert freq_bins == "auto", "`freq_bins` can only be a str if it is equal to 'auto'"
             self.to_periodogram(self.omega)
@@ -604,9 +614,6 @@ class TESSCutLightcurve(BasicLightcurve):
             if isinstance(freq_bins, int):
                 freq_bins = np.logspace(min(self.omega), max(self.omega), freq_bins)
             edges = list(zip(freq_bins[:-1], freq_bins[1:]))
-
-        # mask the pixel powers to only be for pixels in the aperture
-        aperture_powers = np.asarray(self.pixel_periodograms)[self.star_mask.flatten()]
 
         # create a separate frame for each frequency bin
         i = 0

--- a/elk/lightcurve.py
+++ b/elk/lightcurve.py
@@ -580,7 +580,7 @@ class TESSCutLightcurve(BasicLightcurve):
 
         return systematics_model, full_model, full_model_normalized
 
-    def diagnose_lc_periodogram(self, output_path, freq_bins='auto', identifier=''):
+    def diagnose_lc_periodogram(self, output_path, freq_bins='auto', identifier='', save_simbad_queries=True):
         """Create gif showing pixels that contribute power to periodogram for different frequency ranges
 
         The GIF has 3 panels, the first shows the overall TPFs and aperture, the second shows the maximum
@@ -686,7 +686,7 @@ class TESSCutLightcurve(BasicLightcurve):
             i += 1
 
         # convert individual frames to a GIF
-        gif_path = os.path.join(output_path, 'pixel_power_gif.gif')
+        gif_path = os.path.join(output_path, f'{identifier}_pixel_power_gif.gif')
         with imageio.get_writer(gif_path, mode='I', fps=1.5) as writer:
             for i in range(len(edges)):
                 writer.append_data(imageio.imread(os.path.join(output_path,

--- a/elk/lightcurve.py
+++ b/elk/lightcurve.py
@@ -607,8 +607,12 @@ class TESSCutLightcurve(BasicLightcurve):
                                               "`self.correct_lc`")
 
         # mask the pixel powers to only be for pixels in the aperture
+        assert hasattr(self, "star_mask"), "No aperture mask found - have you run `self.correct_lc`?"
         aperture_powers = np.asarray(self.pixel_periodograms)[self.star_mask.flatten()]
         assert len(aperture_powers) > 0, "No pixel periodograms found - did you run `self.correct_lc`?"
+
+        if save_simbad_queries:
+            simbad_queries = []
 
         # convert input into bin edges
         if isinstance(freq_bins, str):

--- a/elk/stats.py
+++ b/elk/stats.py
@@ -3,7 +3,7 @@ import scipy
 from statsmodels.tsa.stattools import acf as calc_acf
 import os
 
-from scipy.signal import find_peaks, argrelextrema
+from scipy.signal import find_peaks, peak_widths, argrelextrema
 import scipy.linalg
 
 from astropy.table import Table
@@ -177,6 +177,10 @@ def periodogram(time, flux, flux_err, frequencies, n_bootstrap=100, max_peaks=25
     peak_threshold = np.mean(med) + 2 * np.std(med)
     peak_inds, peak_info = find_peaks(one_below, height=peak_threshold)
 
+    _, _, peak_left, peak_right = peak_widths(one_below, peak_inds, rel_height=0.5)
+    peak_left = frequencies[np.floor(peak_left).astype(int)]
+    peak_right = frequencies[np.ceil(peak_right).astype(int)]
+
     # calculate how much of our power is coming from timescales shorter/longer than threshold
     low_freq = frequencies > freq_thresh
     ratio_of_power_at_high_v_low_freq = np.mean(med[~low_freq]) / np.mean(med[low_freq])
@@ -197,6 +201,8 @@ def periodogram(time, flux, flux_err, frequencies, n_bootstrap=100, max_peaks=25
         "max_power": max_power,
         "freq_at_max_power": freq_at_max_power,
         "peak_freqs": peak_freqs,
+        "peak_left_edge": peak_left,
+        "peak_right_edge": peak_right,
         "power_at_peaks": power_at_peaks,
         "n_peaks": n_peaks,
         "ratio_of_power_at_high_v_low_freq": ratio_of_power_at_high_v_low_freq

--- a/elk/tests/test_gif.py
+++ b/elk/tests/test_gif.py
@@ -1,0 +1,14 @@
+import elk
+from elk.lightcurve import TESSCutLightcurve
+import lightkurve as lk
+
+search_results = lk.search_tesscut('NGC 7790')
+
+print(search_results[1])
+
+lc = TESSCutLightcurve(radius=2.9/60, lk_search_result=search_results[1], cutout_size=10,
+                       save_pixel_periodograms=True, progress_bar=True)
+
+lc.correct_lc()
+
+print(lc.pixel_periodograms)

--- a/elk/tests/test_gif.py
+++ b/elk/tests/test_gif.py
@@ -1,14 +1,17 @@
 import elk
 from elk.lightcurve import TESSCutLightcurve
 import lightkurve as lk
+import numpy as np
 
 search_results = lk.search_tesscut('NGC 7790')
 
 print(search_results[1])
 
-lc = TESSCutLightcurve(radius=2.9/60, lk_search_result=search_results[1], cutout_size=10,
+lc = TESSCutLightcurve(radius=2.9/60, lk_search_result=search_results[1], cutout_size=20,
                        save_pixel_periodograms=True, progress_bar=True)
 
 lc.correct_lc()
 
 print(lc.pixel_periodograms)
+
+lc.make_periodogram_peak_pixels_gif('.', freq_bins=np.logspace(-1, 1, 5))

--- a/elk/tests/test_gif.py
+++ b/elk/tests/test_gif.py
@@ -13,5 +13,5 @@ lc.correct_lc()
 
 
 start = time()
-lc.diagnose_lc_periodogram('.', freq_bins='auto')
+lc.diagnose_lc_periodogram('.', freq_bins='auto', identifier='NGC 7790')
 print("Runtime:", time() - start)

--- a/elk/tests/test_gif.py
+++ b/elk/tests/test_gif.py
@@ -1,15 +1,17 @@
-import elk
 from elk.lightcurve import TESSCutLightcurve
 import lightkurve as lk
-import numpy as np
+from time import time
 
 search_results = lk.search_tesscut('NGC 7790')
 
 print(search_results[1])
 
-lc = TESSCutLightcurve(radius=2.9/60, lk_search_result=search_results[1], cutout_size=20,
-                       save_pixel_periodograms=True, progress_bar=True)
+lc = TESSCutLightcurve(radius=2.9/60, lk_search_result=search_results[1], cutout_size=40,
+                       save_pixel_periodograms=True, progress_bar=False)
 
 lc.correct_lc()
 
-lc.make_periodogram_peak_pixels_gif('.', freq_bins=np.logspace(-1, 1, 20))
+
+start = time()
+lc.make_periodogram_peak_pixels_gif('.', freq_bins='auto')
+print("Runtime:", time() - start)

--- a/elk/tests/test_gif.py
+++ b/elk/tests/test_gif.py
@@ -12,6 +12,4 @@ lc = TESSCutLightcurve(radius=2.9/60, lk_search_result=search_results[1], cutout
 
 lc.correct_lc()
 
-print(lc.pixel_periodograms)
-
-lc.make_periodogram_peak_pixels_gif('.', freq_bins=np.logspace(-1, 1, 5))
+lc.make_periodogram_peak_pixels_gif('.', freq_bins=np.logspace(-1, 1, 20))

--- a/elk/tests/test_gif.py
+++ b/elk/tests/test_gif.py
@@ -6,12 +6,12 @@ search_results = lk.search_tesscut('NGC 7790')
 
 print(search_results[1])
 
-lc = TESSCutLightcurve(radius=2.9/60, lk_search_result=search_results[1], cutout_size=40,
+lc = TESSCutLightcurve(radius=2.9/60, lk_search_result=search_results[1], cutout_size=20,
                        save_pixel_periodograms=True, progress_bar=False)
 
 lc.correct_lc()
 
 
 start = time()
-lc.make_periodogram_peak_pixels_gif('.', freq_bins='auto')
+lc.diagnose_lc_periodogram('.', freq_bins='auto')
 print("Runtime:", time() - start)


### PR DESCRIPTION
Main changes are adding a `diagnose_lc_periodogram` function that produces the GIF from @tobin-wainer's notebook. Tobin obviously feel free to change the style of the plot, there are comments in the code pointing to locations you might want to change.

The function also has a `save_simbad_queries` option that allows the user to produce a list of [ra, dec, freq_lower, freq_upper]s, which we can then use in SIMBAD to do simple circle queries for each of these pixels and check if there are stars with variability of the right frequency.

I haven't implemented the SIMBAD search itself but need to go pack now and we can do that afterwards, no need to have that set up before trying to run it again.

This closes #55, closes #61 (with the freq_bins='auto' option) and makes progress on #62