### PR TITLE
Automate testing and add JOSS compilation script

### DIFF
--- a/.github/workflows/joss_compile.yml
+++ b/.github/workflows/joss_compile.yml
@@ -1,0 +1,27 @@
+name: Compile JOSS paper
+
+on:
+  push:
+    branches: [ joss ]
+      paths:
+        - 'paper.md'
+        - 'paper.bib'
+  workflow_dispatch:
+
+jobs:
+  paper:
+    runs-on: ubuntu-latest
+    name: Paper Draft
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build draft PDF
+        uses: openjournals/openjournals-draft-action@master
+        with:
+          journal: joss
+          paper-path: paper.md
+      - name: Upload
+        uses: actions/upload-artifact@v1
+        with:
+          name: paper
+          path: paper.pdf

--- a/.github/workflows/perform_tests.yml
+++ b/.github/workflows/perform_tests.yml
@@ -1,0 +1,53 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Run all `elk` tests
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'elk/**'
+      - 'requirements.txt'
+      - 'setup.cfg'
+      - 'setup.py'
+      - 'pyproject.toml'
+    
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'elk/**'
+      - 'requirements.txt'
+      - 'setup.cfg'
+      - 'setup.py'
+      - 'pyproject.toml'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest coverage pytest-xdist nbmake pytest-cov
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install .
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest and generate coverage report
+      run: |
+        pytest elk


### PR DESCRIPTION
Honestly not sure how to test this before actually merging since it needs to exist in GitHub before we can see if I have a bug, so I'm just going to live life dangerously and merge this in immediately @tobin-wainer  and test it out.

FYI this adds actions that:

- Perform our entire test suite any time there is a PR or push to main that changes any of the code or dependencies
- Compile a new JOSS paper any time the files "paper.md"/"paper.bib" are pushed to on the 'joss' branch

This will fix #89 